### PR TITLE
feat: watch base interface for detach actions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export default class HuddlyDeviceApiIP implements IHuddlyDeviceAPI {
     private readonly SUPPORTED_DEVICES: String[] = ['L1'];
 
     constructor(opts: DeviceApiOpts = {}) {
-        this.deviceDiscoveryManager = opts.manager || new DeviceDiscoveryManager();
+        this.deviceDiscoveryManager = opts.manager || new DeviceDiscoveryManager(opts);
     }
 
     async initialize() {}


### PR DESCRIPTION
Make sure we watch the BASE interface during setup in case the interface is disabled. When the interface is re-enabled (connected) again we should be able to rediscover any L1 cameras available through BASE and report back to the SDK