### PR TITLE
feat(WsDiscovery): Add interface name option

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -48,7 +48,10 @@ export default class GrpcTransport extends EventEmitter implements IGrpcTranspor
             );
             this._grpcClient.waitForReady(deadline, error => {
                 if (error) {
-                    Logger.error(`Connection failed. Reason: ${error}`, GrpcTransport.name);
+                    Logger.error(
+                        `Unable to establish grpc connection on address ${this.device.ip}:${this.GRPC_PORT}! ${error}`,
+                        GrpcTransport.name
+                    );
                     reject(error);
                 } else {
                     Logger.debug(`Connection established`, GrpcTransport.name);


### PR DESCRIPTION
- Allow consumer to provide interface name for discovery so that we bind the outgoing multicast interface of the socket to the one provided.
- Allow consumer to exclusively ignore Huddly IP Devices with link local assigned ipv4 addresses. *This was necessary for the CI setup where L1 devices get a link local address the first 2-5 seconds after booting and then the address is updated to a non-link local ip.