### PR TITLE
feat: only link local devices unless probeEntireNetwork is set

### DIFF
--- a/tests/wsdiscovery.spec.ts
+++ b/tests/wsdiscovery.spec.ts
@@ -230,20 +230,25 @@ describe('WsDiscovery', () => {
         });
     });
 
-    describe('#linkLocalAddrAllowed', () => {
+    describe('#isDeviceAllowed', () => {
         it('should allow link local addresses by default', () => {
             wsdd = new WsDiscovery(wsddOptions);
-            const allowed = wsdd.linkLocalAddrAllowed('169.254.10.10');
+            const allowed = wsdd.isDeviceAllowed('169.254.10.10');
             expect(allowed).to.equal(true);
         });
-        it('should be ignored when option says so', () => {
+        it('link local should be ignored when option says so', () => {
             wsdd = new WsDiscovery({ ...wsddOptions, ignoreLinkLocalDevices: true });
-            const allowed = wsdd.linkLocalAddrAllowed('169.254.10.10');
+            const allowed = wsdd.isDeviceAllowed('169.254.10.10');
+            expect(allowed).to.equal(false);
+        });
+        it('should not allow anything beyond link local addresses by default', () => {
+            wsdd = new WsDiscovery(wsddOptions);
+            const allowed = wsdd.isDeviceAllowed('10.1.0.10');
             expect(allowed).to.equal(false);
         });
         it('should be allowed when option says so and ip is non-link local', () => {
-            wsdd = new WsDiscovery({ ...wsddOptions, ignoreLinkLocalDevices: true });
-            const allowed = wsdd.linkLocalAddrAllowed('10.1.0.10');
+            wsdd = new WsDiscovery({ ...wsddOptions, probeEntireNetwork: true });
+            const allowed = wsdd.isDeviceAllowed('10.1.0.10');
             expect(allowed).to.equal(true);
         });
     });


### PR DESCRIPTION
- Should only use link local unless we tell it otherwise
- Have kept the ability to ignore link local networks. Looking at it, I'm not so sure if that's actually nice to have anymore.