### PR TITLE
fix(wsdiscovery): message subscriber should not be an anonymous funtion

### DIFF
--- a/src/wsdiscovery.ts
+++ b/src/wsdiscovery.ts
@@ -337,12 +337,14 @@ export default class WsDiscovery extends EventEmitter {
                 callback(discoveredDevices);
             }, this.opts.timeout);
 
-            socket.on('message', message => {
+            const listener = message => {
                 onProbeResponseHandler(message, probeTimeout);
-            });
+            };
+
+            socket.on('message', listener);
 
             setTimeout(() => {
-                socket.removeListener('message', onProbeResponseHandler);
+                socket.removeListener('message', listener);
             }, this.opts.timeout);
 
             this.setTimeoutWithRandomDelay(


### PR DESCRIPTION
Thought this was handled in the original implementation, but apparently not.